### PR TITLE
Implement initial WebForm AutoTester scaffold

### DIFF
--- a/assertions.py
+++ b/assertions.py
@@ -1,0 +1,19 @@
+"""Success assertion helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, Any
+from playwright.async_api import Page
+
+
+async def assert_success(page: Page, config: Dict[str, Any]) -> None:
+    """Raise ``AssertionError`` if success conditions are not met."""
+
+    selector = config.get("selector")
+    url_contains = config.get("url_contains")
+
+    if selector:
+        await page.wait_for_selector(selector, timeout=5000)
+
+    if url_contains:
+        assert url_contains in page.url, f"Expected '{url_contains}' in {page.url}"

--- a/config/target.json
+++ b/config/target.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://httpbin.org/forms/post",
+  "allowlist": ["httpbin.org"],
+  "assertions": {
+    "url_contains": "/post"
+  }
+}

--- a/generators.py
+++ b/generators.py
@@ -1,0 +1,41 @@
+"""Generate fake values for form fields."""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from faker import Faker
+import rstr
+
+fake = Faker()
+
+
+def generate_value(field_type: str, field) -> Any:
+    """Return a fake value for ``field_type``.
+
+    ``field`` is a :class:`FieldSchema` instance from ``schema_extractor``.
+    Only a small subset of generators are implemented for the demo.
+    """
+
+    if field_type == "email":
+        return fake.email()
+    if field_type == "phone":
+        return fake.phone_number()
+    if field_type == "name":
+        return fake.name()
+    if field_type == "date":
+        return fake.date()
+    if field_type == "zip":
+        return fake.postcode()
+    if field_type == "password":
+        return fake.password(length=12)
+    if field_type == "select":
+        # for selects we simply choose a random option value from DOM
+        options = field.constraints.get("options", [])
+        if options:
+            return random.choice(options)
+        return None
+
+    # default
+    return fake.word()

--- a/infer.py
+++ b/infer.py
@@ -1,0 +1,45 @@
+"""Simple field type inference heuristics."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+from schema_extractor import FieldSchema
+
+
+_PATTERNS = {
+    "email": re.compile(r"email", re.I),
+    "phone": re.compile(r"phone|tel|mobile", re.I),
+    "name": re.compile(r"name", re.I),
+    "date": re.compile(r"date", re.I),
+    "zip": re.compile(r"zip|postal", re.I),
+    "password": re.compile(r"password", re.I),
+}
+
+
+def infer_type(field: FieldSchema) -> str:
+    """Return the logical type for ``field``.
+
+    The function looks at the HTML ``type`` attribute, the field name and any
+    human readable label.  The returned string is used by ``generators`` to
+    create appropriate dummy values.
+    """
+
+    # direct hints from html type
+    type_hint = (field.html_type or "").lower()
+    if type_hint in {"email", "tel", "date", "password"}:
+        return {
+            "tel": "phone",
+            "date": "date",
+        }.get(type_hint, type_hint)
+
+    # Check name/label with regex patterns
+    haystack = " ".join(filter(None, [field.name, field.label]))
+    for key, pattern in _PATTERNS.items():
+        if pattern.search(haystack):
+            return key
+
+    if field.tag == "select":
+        return "select"
+
+    return "text"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+playwright
+faker
+pydantic
+pytest
+pytest-html
+rstr
+python-dateutil

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,96 @@
+"""High level runner that glues all components together."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Dict, Any
+from urllib.parse import urlparse
+
+from playwright.async_api import async_playwright
+
+from schema_extractor import extract_form_schema
+from infer import infer_type
+from generators import generate_value
+from assertions import assert_success
+
+
+async def _fill_page(page, log: Dict[str, Any]):
+    schema = await extract_form_schema(page)
+    for field in schema.fields:
+        field_type = infer_type(field)
+        selector = f"{field.tag}[name='{field.name}']"
+        if field.tag == "input":
+            selector = f"input[name='{field.name}']"
+
+        if field.tag == "select":
+            options = await page.eval_on_selector_all(
+                selector + " option", "opts => opts.map(o => o.value)"
+            )
+            field.constraints["options"] = options
+        value = generate_value(field_type, field)
+        log[field.name] = value
+        if value is None:
+            continue
+        if field.tag == "select":
+            await page.select_option(selector, value)
+        else:
+            try:
+                await page.fill(selector, value)
+            except Exception:
+                # some fields may be read only or hidden; ignore
+                pass
+
+
+async def run(config_path: str = "config/target.json") -> Dict[str, Any]:
+    """Execute the demo runner and return log data."""
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    target_url = config["url"]
+    host = urlparse(target_url).hostname
+    if host not in config.get("allowlist", []):
+        raise ValueError(f"Host '{host}' not in allowlist")
+
+    artifacts = Path("artifacts")
+    artifacts.mkdir(exist_ok=True)
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        context = await browser.new_context()
+        page = await context.new_page()
+
+        await page.goto(target_url)
+        await page.screenshot(path=str(artifacts / "before.png"))
+
+        log: Dict[str, Any] = {}
+        await _fill_page(page, log)
+
+        # Try to find and click a "Next" button to simulate multi-step forms
+        next_btn = await page.query_selector("text=Next")
+        if next_btn:
+            await next_btn.click()
+            await _fill_page(page, log)
+
+        # Submit
+        submit = await page.query_selector("text=Submit")
+        if not submit:
+            submit = await page.query_selector("input[type=submit]")
+        if submit:
+            await submit.click()
+
+        await assert_success(page, config.get("assertions", {}))
+        await page.screenshot(path=str(artifacts / "after.png"))
+
+        with open(artifacts / "log.json", "w") as f:
+            json.dump(log, f, indent=2)
+
+        await context.close()
+        await browser.close()
+        return log
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/schema_extractor.py
+++ b/schema_extractor.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Utilities to extract form schema information from a Playwright page.
+
+This module inspects the DOM of the current page and returns a ``FormSchema``
+object describing all fields that can be filled.  Only very small pieces of the
+real project are implemented – just enough for a proof of concept.
+"""
+
+from typing import List, Optional, Dict
+from pydantic import BaseModel
+from playwright.async_api import Page
+
+
+class FieldSchema(BaseModel):
+    """Representation of a single form field."""
+
+    name: str
+    label: Optional[str] = None
+    html_type: str
+    tag: str
+    constraints: Dict[str, str] = {}
+
+
+class FormSchema(BaseModel):
+    """Schema describing all fields on a page."""
+
+    action: Optional[str] = None
+    fields: List[FieldSchema] = []
+
+
+async def _get_label(page: Page, element) -> Optional[str]:
+    """Try to find a human friendly label for ``element``.
+
+    The heuristic checks associated ``<label for="id">`` tags, ``aria-label``
+    attributes and wrapping ``<label>`` elements.
+    """
+
+    element_id = await element.get_attribute("id")
+    if element_id:
+        label = await page.query_selector(f'label[for="{element_id}"]')
+        if label:
+            text = await label.inner_text()
+            if text:
+                return text.strip()
+
+    aria = await element.get_attribute("aria-label")
+    if aria:
+        return aria.strip()
+
+    # Finally check if element is inside a <label> element
+    text = await element.evaluate(
+        "el => el.closest('label') ? el.closest('label').textContent : null"
+    )
+    if text:
+        return str(text).strip()
+    return None
+
+
+async def extract_form_schema(page: Page) -> FormSchema:
+    """Extract a :class:`FormSchema` from ``page``.
+
+    All ``input``, ``select`` and ``textarea`` elements are inspected.  The
+    returned schema intentionally contains only a subset of possible metadata
+    but is sufficient for the demo.
+    """
+
+    elements = await page.query_selector_all("input, select, textarea")
+    fields: List[FieldSchema] = []
+
+    for el in elements:
+        tag_name = await el.evaluate("e => e.tagName.toLowerCase()")
+        html_type = await el.get_attribute("type") or tag_name
+        name = (
+            await el.get_attribute("name")
+            or await el.get_attribute("id")
+            or tag_name
+        )
+        label = await _get_label(page, el)
+        fields.append(
+            FieldSchema(name=name, label=label, html_type=html_type, tag=tag_name)
+        )
+
+    action = await page.evaluate("document.forms[0] ? document.forms[0].action : null")
+
+    return FormSchema(action=action, fields=fields)

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,16 @@
+import asyncio
+import sys
+from pathlib import Path
+
+
+def test_demo_run(monkeypatch):
+    project_root = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(project_root)
+    sys.path.insert(0, str(project_root))
+    from runner import run
+
+    log = asyncio.run(run("config/target.json"))
+    assert isinstance(log, dict)
+    assert Path("artifacts/before.png").exists()
+    assert Path("artifacts/after.png").exists()
+    assert Path("artifacts/log.json").exists()


### PR DESCRIPTION
## Summary
- extract form schemas from webpages using Playwright and Pydantic
- infer field types and generate realistic fake input values
- add orchestration runner with assertions and demo pytest

## Testing
- `pytest` *(fails: BrowserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bed36cbfb8832f961a23be9a965826